### PR TITLE
impr: OP-1391 Add issue key check to checklist

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,9 +6,10 @@
 
 (eg. Introduces prettier so that we stop debating semantics :D)
 
-#### Checklist (if applicable)
+#### Checklist
 
-- [ ] PR title contains correct Jira issue key
+- [ ] I will squash: PR title conforms to standard commit message format (`feat: XX-1234 ...`)
+- [ ] I will merge without squashing: All commits conforms to standard commit message format (`feat: XX-1234 ...`)
 - [ ] README update
 
 ---

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -8,6 +8,7 @@
 
 #### Checklist (if applicable)
 
+- [ ] PR title contains correct Jira issue key
 - [ ] README update
 
 ---


### PR DESCRIPTION
### Issue Link:

OP-1391

### What does it do?

Adds an item to the default PR checklist to verify that PR title includes the correct Jira issue key.

### Checklist

- [x] I will squash: PR title conforms to standard commit message format (`feat: XX-1234 ...`)
